### PR TITLE
Posix shell

### DIFF
--- a/gcd/nix.py
+++ b/gcd/nix.py
@@ -26,6 +26,7 @@ def sh(cmd, input=None):
         stdin = subprocess.PIPE
     if cmd[-1] == '|' or cmd[-2] == '|':
         stdout = stderr = subprocess.PIPE
+    # Make sure `cmd` has strict POSIX-compatible syntax (no bashisms)
     proc = subprocess.Popen(
         cmd.rstrip('&|'), shell=True, universal_newlines=True,
         stdin=stdin, stdout=stdout, stderr=stderr)

--- a/gcd/store.py
+++ b/gcd/store.py
@@ -280,14 +280,14 @@ class PgTestCase(TestCase):
     db = 'test'
 
     def setUp(self):
-        sh(('{ dropdb --if-exists %s &> /dev/null; } || true', self.db))
+        sh(('{ dropdb --if-exists %s > /dev/null 2>&1 ; } || true', self.db))
         sh(('createdb %s', self.db))
         self._to_close = []
 
     def tearDown(self):
         for conn_or_pool in self._to_close:
             conn_or_pool.close()
-        sh(('{ dropdb %s &> /dev/null; } || true', self.db))
+        sh(('{ dropdb %s > /dev/null 2>&1 ; } || true', self.db))
 
     def connect(self, **kwargs):
         conn = psycopg2.connect(dbname=self.db, **kwargs)


### PR DESCRIPTION
Running the test suite in Ubuntu 19.04 I discovered that although the login shell is `bash`, the default system shell for opening processes is `dash`, a stricter POSIX-compatible version of the Bourne Shell `sh` (https://wiki.ubuntu.com/DashAsBinSh).
This meant that the file descriptor redirection `&>`, which apparently is a "bashism", was generating issues. Rewriting it to use the standard `> file 2>&1` syntax solved the issues.