### PR TITLE
Use numpy docstring convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,4 @@ repos:
     rev: v2.3.0
     hooks:
     - id: flake8
-      additional_dependencies: ['flake8-docstrings', 'pydocstyle>=4.0.0']
+      additional_dependencies: ['flake8-docstrings']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,4 @@ pre-commit
 black
 flake8
 flake8-docstrings
-# pydocstyle 4 implements support for google style docstrings
-pydocstyle>=4.0.0
 pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 88
 max-complexity = 10
-ignore = W503, D1, D413
-docstring-convention = google
+ignore = W503, D1
+docstring-convention = numpy


### PR DESCRIPTION
After some testing of the related tooling I've changed my mind regarding google docstring style vs numpy one:

1. Google style uses more levels of indentation and not every editor has powerful enough rewrapping tools that are able to insert hard breaks while preserving the level of indentation. Even using `gq` with `formatoptions` appropriately set up is a bit cumbersome, since one has to select the region for which to preserve indentation before formatting. But my main target is vscode given that more than half of the team is using it, and there the ReWrap extension, which is rather markdown oriented, is unable to differentiate between more than two levels of indentation. OTOH numpy style is quite similar to markdown and its usage of indentation to separate sections is limited.
2. vscode shows numpy style docstring tooltips quite neatly formatted, while it's often broken by corner cases of google style docstrings. I believe this is a consequence of the comparatively low popularity of google style wrt numpy style. So numpy style is not only easier to write but also easier to read.
3. People in data related teams might have already been exposed to code in the python scientific stack, which is consistently formatted using numpy style. Also, it is to expect that tooling for scientific applications will support numpy conventions more or less out of the box.
4. Some other projects in jampp already adopted it.