### PR TITLE
PX-153 Do not configure pylint in a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: stable
-    hooks:
-    - id: black
-      language_version: python3.7
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    - id: flake8
-      additional_dependencies: ['flake8-docstrings']
--   repo: local
-    hooks:
-    -   id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
+- repo: https://github.com/psf/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.7
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: flake8
+    additional_dependencies: ['flake8-docstrings']
+- repo: local
+  hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    language: system
+    types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
     rev: v2.4.1
     hooks:
     - id: pylint
-      args:
-      - --disable=import-error
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,15 @@ repos:
     hooks:
     - id: black
       language_version: python3.7
--   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.4.1
-    hooks:
-    - id: pylint
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
     - id: flake8
       additional_dependencies: ['flake8-docstrings']
+-   repo: local
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]

--- a/gcd/store.py
+++ b/gcd/store.py
@@ -237,7 +237,7 @@ class PgVacuumer:
             sr = 100 * n / max(stats.total_tuples, n)
             for clause in "TABLESAMPLE SYSTEM(%s)" % sr, "LIMIT %s" % n:
                 with Transaction(self._conn_or_pool):
-                    stats.tuple_size, = execute(
+                    (stats.tuple_size,) = execute(
                         """
                         SELECT avg(t.s) FROM (
                             SELECT pg_column_size(t.*) AS s FROM %s t %s) t


### PR DESCRIPTION
Veo dos problemas en el approach actual:

* la configuración de pylint no es algo específico del pre-commit hook, para eso está .pylintrc que también ese usada por otras herramientas (editores, IDEs, etc).
* prefiero tener la validación de imports activa.

Respecto al primer punto: la razón por la que estaba así es que es difícil de configurar pylint con pre-commit, en este caso el problema es de la interacción entre ambas partes. Tuve que cambiar la configuración del pre-commit hook de pylint por el tema de los imports. Ver https://github.com/pre-commit/pre-commit/issues/362.

Respecto al segundo punto: si molesta en algún caso en particular pylint tiene mecanismos de desactivación locales muy flexibles (mucho más que los de flake8). La lista actual de excludes fue tomada de una configuración estándar de vscode, cualquier incorporación debe ser consensuada y el mecanismo por defecto debe ser anular localmente un chequeo, no globalmente.

También:
* reformateos que disparó el hook de black: prendan sus pre-commit hooks, por favor!